### PR TITLE
Use Object to store roles

### DIFF
--- a/__tests__/getMissingRoles.spec.js
+++ b/__tests__/getMissingRoles.spec.js
@@ -1,7 +1,7 @@
 import getMissingRoles from "../src/utils/getMissingRoles";
 
 test("getMissingRoles should return the missing roles", () => {
-  const roles = ["user"];
+  const roles = { user: true };
   const neededRoles = ["user", "admin"];
   const missingRoles = getMissingRoles(neededRoles, roles);
   expect(missingRoles).toHaveLength(1);
@@ -9,14 +9,14 @@ test("getMissingRoles should return the missing roles", () => {
 });
 
 test("getMissingRoles should return an empty array if each role is present", () => {
-  const roles = ["user", "admin"];
+  const roles = { user: true, admin: true };
   const neededRoles = ["user", "admin"];
   const missingRoles = getMissingRoles(neededRoles, roles);
   expect(missingRoles).toHaveLength(0);
 });
 
 test("getMissingRoles should return an empty array if no role is needed", () => {
-  const roles = ["user", "admin"];
+  const roles = { user: true, admin: true };
   const neededRoles = [];
   const missingRoles = getMissingRoles(neededRoles, roles);
   expect(missingRoles).toHaveLength(0);

--- a/__tests__/mapArrayToObj.js
+++ b/__tests__/mapArrayToObj.js
@@ -1,0 +1,19 @@
+import mapArrayToObj from "../src/utils/mapArrayToObj";
+
+test("should return an object with array entries as keys", () => {
+  const array = ['a', 'b', 'c'];
+  const obj = mapArrayToObj(array);
+  const expected = {
+    'a': true,
+    'b': true,
+    'c': true,
+  }
+  expect(obj).toEqual(expected);
+});
+
+test('should return an empty object when an empty array is passed', () => {
+  const array = [];
+  const obj = mapArrayToObj(array);
+  const expected = {}
+  expect(obj).toEqual(expected);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import React from "react";
 import t from 'prop-types';
 import getMissingRoles from "./utils/getMissingRoles";
+import mapArrayToObj from "./utils/mapArrayToObj";
 
 const { Consumer, Provider } = React.createContext("authorizator");
 
 class AuthProvider extends React.Component {
   render() {
-    const { roles, children } = this.props;
+    const { children } = this.props;
+    const roles = mapArrayToObj(this.props.roles)
     return (
       <Provider value={{ roles }}>
         {children}

--- a/src/utils/getMissingRoles.js
+++ b/src/utils/getMissingRoles.js
@@ -1,3 +1,3 @@
 const getMissingRoles = (shouldHave, has) =>
-  has ? shouldHave.filter(should => has.indexOf(should) < 0) : shouldHave;
+  shouldHave.filter(should => !has.hasOwnProperty(should));
 export default getMissingRoles;

--- a/src/utils/mapArrayToObj.js
+++ b/src/utils/mapArrayToObj.js
@@ -1,0 +1,4 @@
+export default arr => arr.reduce((obj, entry) => {
+  obj[entry] = true;
+  return obj;
+}, {})


### PR DESCRIPTION
As in #5 discussed.
Use an object internally to store the roles to boost performance.

Whether or not we use something like memoize can be discussed further.