### PR TITLE
Use plain object as default context value

### DIFF
--- a/src/AuthContext.js
+++ b/src/AuthContext.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const { Consumer, Provider } = React.createContext('authorizator');
+const { Consumer, Provider } = React.createContext({});
 
 export {
   Consumer,


### PR DESCRIPTION
Since the Authorize component uses object destructuring
we set an empty object as default value.

Handles #20 