### PR TITLE
Consistent equality

### DIFF
--- a/__tests__/usage.spec.jsx
+++ b/__tests__/usage.spec.jsx
@@ -1,3 +1,6 @@
+/* eslint react/no-multi-comp: 0 */
+/* eslint react/no-unused-state: 0 */
+
 import React from 'react';
 import { render } from 'react-testing-library';
 import { AuthProvider, Authorize } from '../src/index';
@@ -94,6 +97,7 @@ test('no unrequired rerender', () => {
         triggerRerender: true,
       });
     }
+
     render() {
       return (
         <AuthProvider roles={roles}>
@@ -109,6 +113,7 @@ test('no unrequired rerender', () => {
     shouldComponentUpdate() {
       return false;
     }
+
     render() {
       return (
         <Authorize neededRoles={neededRoles}>{renderOnlyOnceMock}</Authorize>
@@ -132,6 +137,7 @@ test('rerender when required', () => {
         roles: [],
       };
     }
+
     componentDidMount() {
       // trigger a rerender directly after the component has been attached
       // and all others have been mounted as well
@@ -139,6 +145,7 @@ test('rerender when required', () => {
         roles: ['admin'],
       });
     }
+
     render() {
       return (
         <AuthProvider roles={this.state.roles}>
@@ -154,6 +161,7 @@ test('rerender when required', () => {
     shouldComponentUpdate() {
       return false;
     }
+
     render() {
       return (
         <Authorize neededRoles={neededRoles}>

--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -3,15 +3,25 @@ import t from 'prop-types';
 import mapArrayToObj from './utils/mapArrayToObj';
 import { Provider } from './AuthContext';
 
-const AuthProvider = (props) => {
-  const { children } = props;
-  const roles = mapArrayToObj(props.roles);
-  return (
-    <Provider value={{ roles }}>
-      {children}
-    </Provider>
-  );
-};
+class AuthProvider extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    const { roles } = props;
+    if (state && state.auth.rolesReference === roles) {
+      return null;
+    }
+    return {
+      auth: {
+        rolesReference: roles,
+        roles: mapArrayToObj(roles),
+      },
+    };
+  }
+
+  render() {
+    const { children } = this.props;
+    return <Provider value={this.state.auth}>{children}</Provider>;
+  }
+}
 
 AuthProvider.propTypes = {
   roles: t.arrayOf(t.string).isRequired,

--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -7,9 +7,9 @@ class AuthProvider extends React.Component {
   static getDerivedStateFromProps(props, state) {
     const { roles } = props;
     const isStateSet = !!state;
-    const isSameRolesObjectAsBefore =
+    const isSameRolesObjectRefAsBefore =
       isStateSet && state.auth.rolesReference === roles;
-    if (isSameRolesObjectAsBefore) {
+    if (isSameRolesObjectRefAsBefore) {
       return null;
     }
     return {

--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -6,11 +6,15 @@ import { Provider } from './AuthContext';
 class AuthProvider extends React.Component {
   static getDerivedStateFromProps(props, state) {
     const { roles } = props;
-    if (state && state.auth.rolesReference === roles) {
+    const isStateSet = !!state;
+    const isSameRolesObjectAsBefore =
+      isStateSet && state.auth.rolesReference === roles;
+    if (isSameRolesObjectAsBefore) {
       return null;
     }
     return {
       auth: {
+        // store a object reference to the original roles array
         rolesReference: roles,
         roles: mapArrayToObj(roles),
       },


### PR DESCRIPTION
Make the provided context value consistent between multiple renders.

The same value will now be reused across different renders. Fixes #13.